### PR TITLE
Adding deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src/cljs"
+         "src/js"
+         "src/cljc"
+         "src/clj"]}
+


### PR DESCRIPTION
Hi thanks for sharing this library. I got it working in Clojurescript project using deps.edn and figwheel. For clj I don't have it working yet (see below, guess some missing dep)

Create a file deps.edn with:
```clojure
{ :deps { com.github.Sepia-Officinalis/secp256k1 
  {:git/url "https://github.com/jeroenvandijk/secp256k1.git"
   :sha "ad7e3f049d79b629c91ca379311c80d0a66df119"}}}
```

Then this happens:
```
clj -R:repl
Cloning: https://github.com/jeroenvandijk/secp256k1.git
Checking out: https://github.com/jeroenvandijk/secp256k1.git at ad7e3f049d79b629c91ca379311c80d0a66df119
Clojure 1.9.0
user=> (require '[secp256k1.hashes])
CompilerException java.lang.ClassNotFoundException: org.bouncycastle.crypto.digests.RIPEMD160Digest, compiling:(secp256k1/hashes.clj:1:1)
```


